### PR TITLE
fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ ZoomMtg.join({
   userName: userName,
   apiKey: apiKey,
   userEmail: userEmail,
-  passWord: password,
+  password: password,
   success: (success) => {
     console.log(success)
   },


### PR DESCRIPTION
passWord in the ZoomMtg.join parameter object should be password.